### PR TITLE
tune kubesphere custom rules

### DIFF
--- a/addons/etcd-mixin/rules/etcd.libsonnet
+++ b/addons/etcd-mixin/rules/etcd.libsonnet
@@ -47,12 +47,6 @@
           },
           {
             expr: |||
-              sum(label_replace(etcd_debugging_mvcc_db_total_size_in_bytes{%(etcd_selector)s},"node", "$1", "%(etcd_instance_labels)s", "(.*):.*")) by (node)
-            ||| % {etcd_selector: $._config.etcd_selector, etcd_instance_labels: $._config.etcd_instance_labels},
-            record: 'etcd:etcd_debugging_mvcc_db_total_size:sum',
-          },
-          {
-            expr: |||
               sum(label_replace(etcd_mvcc_db_total_size_in_bytes{%(etcd_selector)s},"node", "$1", "%(etcd_instance_labels)s", "(.*):.*")) by (node)
             ||| % {etcd_selector: $._config.etcd_selector, etcd_instance_labels: $._config.etcd_instance_labels},
             record: 'etcd:etcd_mvcc_db_total_size:sum',

--- a/addons/k8s-mixin/alerts/alerts.libsonnet
+++ b/addons/k8s-mixin/alerts/alerts.libsonnet
@@ -1,0 +1,13 @@
+(import 'kubernetes-mixin/alerts/alerts.libsonnet') + {
+    prometheusAlerts+: {
+        groups: std.filterMap(
+            function(g) $._config.kubeProxy || g.name != 'kubernetes-system-kube-proxy', 
+            function(g) if g.name != 'kubernetes-apps' then g else g + {
+                  rules: std.map(function(r) r + {
+                      expr: std.strReplace(super.expr, 'kube_daemonset_updated_number_scheduled', 'kube_daemonset_status_updated_number_scheduled'),
+                      }, 
+                    super.rules),
+                }, 
+            super.groups),
+    },
+}

--- a/addons/k8s-mixin/config.libsonnet
+++ b/addons/k8s-mixin/config.libsonnet
@@ -2,5 +2,6 @@
   _config+:: {
     kubeCoreDNSSelector: 'job="coredns"',
     prometheusSelector: 'job="prometheus"',
+    kubeProxy: false,
   },
 }

--- a/addons/k8s-mixin/mixin.libsonnet
+++ b/addons/k8s-mixin/mixin.libsonnet
@@ -1,4 +1,4 @@
-(import 'kubernetes-mixin/alerts/alerts.libsonnet') +
+(import 'alerts/alerts.libsonnet') +
 (import 'rules/rules.libsonnet') +
 (import 'kubernetes-mixin/dashboards/dashboards.libsonnet') +
 (import 'config.libsonnet')

--- a/addons/k8s-monitor-patch.libsonnet
+++ b/addons/k8s-monitor-patch.libsonnet
@@ -1,9 +1,11 @@
 {
   kubernetesControlPlane+: {
-    local mixinConfig = super._config.mixin._config,
+    local config = super._config,
+    local mixinConfig = config.mixin._config,
     mixin:: (import './k8s-mixin/mixin.libsonnet') + {
       _config+:: mixinConfig + {
         prometheusSelector: $.prometheus._config.mixin._config.prometheusSelector,
+        kubeProxy: config.kubeProxy,
       },
     },
 

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -18,7 +18,7 @@
           "subdir": "contrib/mixin"
         }
       },
-      "version": "96a9fd0a1e2a2887ebcf3b8eba90d8f0a881e77b",
+      "version": "f184dfd9dc981cff3968789dc48a2be0d0b80747",
       "sum": "cdKL5kPYfpWSpTCu4qctmh+gWQqL+4YWom6rw9qLYJU="
     },
     {
@@ -38,7 +38,7 @@
           "subdir": "grafana-builder"
         }
       },
-      "version": "264a5c2078c5930af57fe2d107eff83ab63553af",
+      "version": "0db65aa79a959234109566044b33d76edb0ca9d8",
       "sum": "0KkygBQd/AFzUvVzezE4qF/uDYgrwUXVpZfINBti0oc="
     },
     {
@@ -58,7 +58,7 @@
           "subdir": "lib/promgrafonnet"
         }
       },
-      "version": "fd913499e956da06f520c3784c59573ee552b152",
+      "version": "3346c8cbcc1660caeddf2ffc9443dabe583e1a35",
       "sum": "zv7hXGui6BfHzE9wPatHI/AGZa4A2WKo6pq7ZdqBsps="
     },
     {

--- a/manifests/etcd/prometheus-rulesEtcd.yaml
+++ b/manifests/etcd/prometheus-rulesEtcd.yaml
@@ -173,9 +173,6 @@ spec:
         sum(label_replace(sum(etcd_server_proposals_pending{job=~".*etcd.*"}) by (instance), "node", "$1", "instance", "(.*):.*")) by (node)
       record: etcd:etcd_server_proposals_pending:sum
     - expr: |
-        sum(label_replace(etcd_debugging_mvcc_db_total_size_in_bytes{job=~".*etcd.*"},"node", "$1", "instance", "(.*):.*")) by (node)
-      record: etcd:etcd_debugging_mvcc_db_total_size:sum
-    - expr: |
         sum(label_replace(etcd_mvcc_db_total_size_in_bytes{job=~".*etcd.*"},"node", "$1", "instance", "(.*):.*")) by (node)
       record: etcd:etcd_mvcc_db_total_size:sum
     - expr: |

--- a/manifests/kubernetes/kubernetes-prometheusRule.yaml
+++ b/manifests/kubernetes/kubernetes-prometheusRule.yaml
@@ -140,7 +140,7 @@ spec:
              !=
             0
           ) or (
-            kube_daemonset_updated_number_scheduled{job="kube-state-metrics"}
+            kube_daemonset_status_updated_number_scheduled{job="kube-state-metrics"}
              !=
             kube_daemonset_status_desired_number_scheduled{job="kube-state-metrics"}
           ) or (
@@ -149,7 +149,7 @@ spec:
             kube_daemonset_status_desired_number_scheduled{job="kube-state-metrics"}
           )
         ) and (
-          changes(kube_daemonset_updated_number_scheduled{job="kube-state-metrics"}[5m])
+          changes(kube_daemonset_status_updated_number_scheduled{job="kube-state-metrics"}[5m])
             ==
           0
         )
@@ -700,18 +700,6 @@ spec:
       for: 15m
       labels:
         severity: critical
-  - name: kubernetes-system-kube-proxy
-    rules:
-    - alert: KubeProxyDown
-      annotations:
-        description: KubeProxy has disappeared from Prometheus target discovery.
-        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeproxydown
-        summary: Target disappeared from Prometheus target discovery.
-      expr: |
-        absent(up{job="kube-proxy"} == 1)
-      for: 15m
-      labels:
-        severity: critical
   - name: k8s.rules
     rules:
     - expr: |
@@ -728,14 +716,14 @@ spec:
       record: namespace:container_memory_usage_bytes_wo_cache:sum
     - expr: |
         sum by (namespace, label_name) (
-            sum(kube_pod_container_resource_requests_memory_bytes{job="kube-state-metrics"} * on (endpoint, instance, job, namespace, pod, service) group_left(phase) (kube_pod_status_phase{phase=~"Pending|Running"} == 1)) by (namespace, pod)
+            sum(kube_pod_container_resource_requests{resource="memory", job="kube-state-metrics"} * on (endpoint, instance, job, namespace, pod, service) group_left(phase) (kube_pod_status_phase{phase=~"Pending|Running"} == 1)) by (namespace, pod)
           * on (namespace, pod)
             group_left(label_name) kube_pod_labels{job="kube-state-metrics"}
         )
       record: namespace:kube_pod_container_resource_requests_memory_bytes:sum
     - expr: |
         sum by (namespace, label_name) (
-            sum(kube_pod_container_resource_requests_cpu_cores{job="kube-state-metrics"} * on (endpoint, instance, job, namespace, pod, service) group_left(phase) (kube_pod_status_phase{phase=~"Pending|Running"} == 1)) by (namespace, pod)
+            sum(kube_pod_container_resource_requests{resource="cpu", job="kube-state-metrics"} * on (endpoint, instance, job, namespace, pod, service) group_left(phase) (kube_pod_status_phase{phase=~"Pending|Running"} == 1)) by (namespace, pod)
           * on (namespace, pod)
             group_left(label_name) kube_pod_labels{job="kube-state-metrics"}
         )
@@ -860,7 +848,7 @@ spec:
         sum by (node, host_ip, role) ((kube_pod_status_scheduled{job="kube-state-metrics", condition="true"} > 0)  * on (namespace, pod) group_left(node, host_ip, role) node_namespace_pod:kube_pod_info:)
       record: node:pod_count:sum
     - expr: |
-        (sum(kube_node_status_capacity_pods{job="kube-state-metrics"}) by (node) * on(node) group_left(host_ip, role) max by(node, host_ip, role) (node_namespace_pod:kube_pod_info:))
+        (sum(kube_node_status_capacity{resource="pods", job="kube-state-metrics"}) by (node) * on(node) group_left(host_ip, role) max by(node, host_ip, role) (node_namespace_pod:kube_pod_info:))
       record: node:pod_capacity:sum
     - expr: |
         node:pod_running:count / node:pod_capacity:sum
@@ -901,7 +889,7 @@ spec:
         count(kube_pod_info{job="kube-state-metrics"} and on (pod, namespace) (kube_pod_status_phase{job="kube-state-metrics", phase="Running"}>0))
       record: cluster:pod_running:count
     - expr: |
-        cluster:pod_running:count / sum(kube_node_status_capacity_pods)
+        cluster:pod_running:count / sum(kube_node_status_capacity{resource="pods", job="kube-state-metrics"})
       record: cluster:pod_utilization:ratio
     - expr: |
         1 - sum(max(node_filesystem_avail_bytes{device=~"/dev/.*", device!~"/dev/loop\\d+", job="node-exporter"}) by (device, instance)) / sum(max(node_filesystem_size_bytes{device=~"/dev/.*", device!~"/dev/loop\\d+", job="node-exporter"}) by (device, instance))
@@ -918,7 +906,7 @@ spec:
   - name: namespace.rules
     rules:
     - expr: |
-        (count(kube_pod_info{job="kube-state-metrics", node!=""}) by (namespace) - sum(kube_pod_status_phase{job="kube-state-metrics", phase="Succeeded"}) by (namespace)  - sum(kube_pod_status_ready{job="kube-state-metrics", condition="true"} * on (pod, namespace) kube_pod_status_phase{job="kube-state-metrics", phase="Running"}) by (namespace) - sum(kube_pod_container_status_waiting_reason{job="kube-state-metrics", reason="ContainerCreating"}) by (namespace)) * on (namespace) group_left(workspace)(kube_namespace_labels{job="kube-state-metrics"})
+        (count by(namespace) (kube_pod_info{job="kube-state-metrics"} unless on(pod, namespace) (kube_pod_status_phase{job="kube-state-metrics",phase="Succeeded"} > 0) unless on(pod, namespace) ((kube_pod_status_ready{condition="true",job="kube-state-metrics"} > 0) and on(pod, namespace) (kube_pod_status_phase{job="kube-state-metrics",phase="Running"} > 0)) unless on(pod, namespace) kube_pod_container_status_waiting_reason{job="kube-state-metrics",reason="ContainerCreating"} > 0) or on(namespace) (group by(namespace) (kube_pod_info{job="kube-state-metrics"}) * 0)) * on(namespace) group_left(workspace) (kube_namespace_labels{job="kube-state-metrics"}) > 0
       record: namespace:pod_abnormal:count
     - expr: |
         namespace:pod_abnormal:count / (sum(kube_pod_status_phase{job="kube-state-metrics", phase!="Succeeded", namespace!=""}) by (namespace) * on (namespace) group_left(workspace)(kube_namespace_labels{job="kube-state-metrics"}))


### PR DESCRIPTION
This is for KubeSphere built-in customzied rules compatibility with upstream components, whose metrics changes mainly refer to kube-state-metrics v2.0.0+ [CHANGELOG](https://github.com/kubernetes/kube-state-metrics/blob/master/CHANGELOG.md).  

The rule `etcd:etcd_debugging_mvcc_db_total_size:sum` is removed because metric `etcd_debugging_mvcc_db_total_size_in_bytes`  is deprecated in [etcd v3.5.0](https://github.com/etcd-io/etcd/blob/main/CHANGELOG-3.5.md#v350-2021-06). The rule `etcd:etcd_mvcc_db_total_size:sum` like it should be used.

