### PR TITLE
disable processes collector for node exporter

### DIFF
--- a/addons/node-exporter-patch.libsonnet
+++ b/addons/node-exporter-patch.libsonnet
@@ -5,20 +5,6 @@
       _config+:: mixinConfig,
     },
 
-    local ne = self,
-    daemonset+: {
-      spec+: {
-        template+: {
-          spec+: {
-            containers: std.map(
-              function(c)
-                if c.name != ne._config.name then c
-                else c {args+: ['--collector.processes']},
-            super.containers),
-          },
-        },
-      },
-    },
     serviceMonitor+: {
       spec+: {
         endpoints: [{
@@ -65,7 +51,6 @@
               'node_filesystem_readonly',
               'node_load.+',
               'node_timex_offset_seconds',
-              'node_processes_.+',
             ]),
           }],
         },],

--- a/manifests/node-exporter/node-exporter-daemonset.yaml
+++ b/manifests/node-exporter/node-exporter-daemonset.yaml
@@ -41,7 +41,6 @@ spec:
         - --collector.filesystem.mount-points-exclude=^/(dev|proc|sys|run/k3s/containerd/.+|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)
         - --collector.netclass.ignored-devices=^(veth.*|[a-f0-9]{15})$
         - --collector.netdev.device-exclude=^(veth.*|[a-f0-9]{15})$
-        - --collector.processes
         image: prom/node-exporter:v1.3.1
         name: node-exporter
         resources:

--- a/manifests/node-exporter/node-exporter-serviceMonitor.yaml
+++ b/manifests/node-exporter/node-exporter-serviceMonitor.yaml
@@ -15,7 +15,7 @@ spec:
     interval: 1m
     metricRelabelings:
     - action: keep
-      regex: node_(uname|network)_info|node_cpu_.+|node_memory_Mem.+_bytes|node_memory_SReclaimable_bytes|node_memory_Cached_bytes|node_memory_Buffers_bytes|node_network_(.+_bytes_total|up)|node_network_.+_errs_total|node_nf_conntrack_entries.*|node_disk_.+_completed_total|node_disk_.+_bytes_total|node_filesystem_files|node_filesystem_files_free|node_filesystem_avail_bytes|node_filesystem_size_bytes|node_filesystem_free_bytes|node_filesystem_readonly|node_load.+|node_timex_offset_seconds|node_processes_.+
+      regex: node_(uname|network)_info|node_cpu_.+|node_memory_Mem.+_bytes|node_memory_SReclaimable_bytes|node_memory_Cached_bytes|node_memory_Buffers_bytes|node_network_(.+_bytes_total|up)|node_network_.+_errs_total|node_nf_conntrack_entries.*|node_disk_.+_completed_total|node_disk_.+_bytes_total|node_filesystem_files|node_filesystem_files_free|node_filesystem_avail_bytes|node_filesystem_size_bytes|node_filesystem_free_bytes|node_filesystem_readonly|node_load.+|node_timex_offset_seconds
       sourceLabels:
       - __name__
     port: https


### PR DESCRIPTION
Remove arg `--collector.processes`  for node exporter to disable node processes/threads metrics collection