### PR TITLE
change some rule names

### DIFF
--- a/addons/k8s-mixin/rules/kubesphere.libsonnet
+++ b/addons/k8s-mixin/rules/kubesphere.libsonnet
@@ -38,7 +38,7 @@
             ||| % $._config,
           },
           {
-            record: 'namespace:kube_pod_container_resource_requests_memory_bytes:sum',
+            record: 'namespace_memory:kube_pod_container_resource_requests:sum',
             expr: |||
               sum by (namespace, label_name) (
                   sum(kube_pod_container_resource_requests{resource="memory", %(kubeStateMetricsSelector)s} * on (endpoint, instance, job, namespace, pod, service) group_left(phase) (kube_pod_status_phase{phase=~"Pending|Running"} == 1)) by (namespace, pod)
@@ -48,7 +48,7 @@
             ||| % $._config,
           },
           {
-            record: 'namespace:kube_pod_container_resource_requests_cpu_cores:sum',
+            record: 'namespace_cpu:kube_pod_container_resource_requests:sum',
             expr: |||
               sum by (namespace, label_name) (
                   sum(kube_pod_container_resource_requests{resource="cpu", %(kubeStateMetricsSelector)s} * on (endpoint, instance, job, namespace, pod, service) group_left(phase) (kube_pod_status_phase{phase=~"Pending|Running"} == 1)) by (namespace, pod)

--- a/manifests/kubernetes/kubernetes-prometheusRule.yaml
+++ b/manifests/kubernetes/kubernetes-prometheusRule.yaml
@@ -720,14 +720,14 @@ spec:
           * on (namespace, pod)
             group_left(label_name) kube_pod_labels{job="kube-state-metrics"}
         )
-      record: namespace:kube_pod_container_resource_requests_memory_bytes:sum
+      record: namespace_memory:kube_pod_container_resource_requests:sum
     - expr: |
         sum by (namespace, label_name) (
             sum(kube_pod_container_resource_requests{resource="cpu", job="kube-state-metrics"} * on (endpoint, instance, job, namespace, pod, service) group_left(phase) (kube_pod_status_phase{phase=~"Pending|Running"} == 1)) by (namespace, pod)
           * on (namespace, pod)
             group_left(label_name) kube_pod_labels{job="kube-state-metrics"}
         )
-      record: namespace:kube_pod_container_resource_requests_cpu_cores:sum
+      record: namespace_cpu:kube_pod_container_resource_requests:sum
   - name: node.rules
     rules:
     - expr: |


### PR DESCRIPTION
rename `namespace:kube_pod_container_resource_requests_memory_bytes:sum` to `namespace_memory:kube_pod_container_resource_requests:sum` used by `KubeMemoryOvercommit`

rename `namespace:kube_pod_container_resource_requests_cpu_cores:sum` to `namespace_cpu:kube_pod_container_resource_requests:sum` used by `KubeCPUOvercommit`