### PR TITLE
revert prometheus service monitor selector

### DIFF
--- a/main.jsonnet
+++ b/main.jsonnet
@@ -76,7 +76,7 @@ local kp = std.mapWithKey(
       [if v2.kind == 'ServiceMonitor' then 'metadata']+: {
         labels+: serviceMonitorSelectorLabels,
       },
-      [if v2.kind == 'Prometheus' then 'spec']+: {serviceMonitorSelector: {matchLabels: serviceMonitorSelectorLabels}},
+      // [if v2.kind == 'Prometheus' then 'spec']+: {serviceMonitorSelector: {matchLabels: serviceMonitorSelectorLabels}},
       // set servicemonitor scrape interval to 1m
       [if v2.kind == 'ServiceMonitor' && 'spec' in v2 then 'spec']+: {
         [if 'endpoints' in v2.spec then 'endpoints']: std.map(function(ep) ep {interval: '1m'}, v2.spec.endpoints),

--- a/manifests/prometheus/prometheus-prometheus.yaml
+++ b/manifests/prometheus/prometheus-prometheus.yaml
@@ -74,7 +74,5 @@ spec:
     runAsUser: 1000
   serviceAccountName: prometheus-k8s
   serviceMonitorNamespaceSelector: {}
-  serviceMonitorSelector:
-    matchLabels:
-      app.kubernetes.io/vendor: kubesphere
+  serviceMonitorSelector: {}
   version: 2.34.0


### PR DESCRIPTION
Revert prometheus `serviceMonitorSelector` to `{}`, because its current config affects other components in kubesphere, such as gateway monitoring.

The limit of `serviceMonitorSelector` is to support the coexistence of muliple prometheus managed by the prometheus-operator,  which will be deferred to the next release of kubesphere. An special issue will be opened later for tracking to accommodate the update to all possible components.

